### PR TITLE
Add heroku config file to enable heroku deployments on PR builds. This will allow changes to be deployed automatically so those reviewing PRs can functionally test easily.

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,0 +1,27 @@
+{
+  "name": "cds-hooks-sandbox",
+  "success_url": "/",
+  "scripts": {},
+  "env": {
+    "NODE_ENV": {
+      "description": "development environment",
+      "value": "development"
+    },
+    "NPM_CONFIG_PRODUCTION": {
+      "description": "development environment",
+      "value": "false"
+    },
+    "NODE_MODULES_CACHE": {
+      "description": "No cache",
+      "value": "false"
+    }
+  },
+  "formation": {
+    "web": {
+      "quantity": 1,
+      "size": "free"
+    }
+  },
+  "addons": [],
+  "buildpacks": []
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3142,6 +3142,35 @@
         "fill-range": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz"
       }
     },
+    "exports-loader": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/exports-loader/-/exports-loader-0.6.4.tgz",
+      "integrity": "sha1-1w/GEhl1s1/BKDDPUnVL4nQPyIY=",
+      "dev": true,
+      "requires": {
+        "loader-utils": "1.1.0",
+        "source-map": "0.5.6"
+      },
+      "dependencies": {
+        "loader-utils": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+          "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+          "dev": true,
+          "requires": {
+            "big.js": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1"
+          }
+        },
+        "source-map": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+          "dev": true
+        }
+      }
+    },
     "express": {
       "version": "4.15.3",
       "resolved": "https://registry.npmjs.org/express/-/express-4.15.3.tgz",
@@ -3221,6 +3250,34 @@
         "ansi-green": "https://registry.npmjs.org/ansi-green/-/ansi-green-0.1.1.tgz",
         "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
         "success-symbol": "https://registry.npmjs.org/success-symbol/-/success-symbol-0.1.0.tgz"
+      }
+    },
+    "extract-text-webpack-plugin": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/extract-text-webpack-plugin/-/extract-text-webpack-plugin-0.3.8.tgz",
+      "integrity": "sha1-CofYYeANW/O+13XpW59Ebsx51C8=",
+      "dev": true,
+      "requires": {
+        "async": "0.2.10",
+        "loader-utils": "0.2.17",
+        "source-map": "0.1.43"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.2.10",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.1.43",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+          "dev": true,
+          "requires": {
+            "amdefine": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+          }
+        }
       }
     },
     "extsprintf": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
     "bootstrap": "*",
     "bootstrap-webpack": "*",
     "css-loader": "*",
+    "exports-loader": "^0.6.2",
+    "express": "~4.15.3",
+    "extract-text-webpack-plugin": "^0.3.8",
     "file-loader": "*",
     "gulp": "^3.9.0",
     "gulp-gh-pages": "^0.5.2",
@@ -51,8 +54,11 @@
   },
   "scripts": {
     "build": "webpack -p --config webpack.prod.config.js",
+    "compile:heroku": "webpack -p --config webpack.prod.config.js --progress",
     "dev-frontend": "webpack-dev-server --host 0.0.0.0 --config webpack.dev.config.js --colors --content-base ./build",
     "dev-services": "nodemon mock-cds-backend/index.js",
+    "heroku-posbuild": "npm install --only=dev && npm run compile:heroku",
+    "start": "node scripts/express/app.js",
     "test": "jest"
   },
   "author": "",

--- a/scripts/express/app.js
+++ b/scripts/express/app.js
@@ -1,0 +1,12 @@
+/* eslint-disable import/no-extraneous-dependencies */
+/* eslint-disable no-console */
+const express = require('express');
+const path = require('path');
+
+const app = express();
+const port = process.env.PORT || 8081;
+// path to webpack built path
+const buildPath = path.join(__dirname, '../../build');
+
+app.use(express.static(buildPath));
+app.listen(port);


### PR DESCRIPTION
Currently, to check out a possible change for the CDS Hooks Sandbox tool, you have to pull down the changes from the compare branch and run the changes locally. Or someone has to deploy to an external `gh-pages` branch to show changes. It would be nice if the changes proposed in a PR can be deployed on a Heroku instance automatically. 

This would allow for ease of testing and better visibility for those looking to check out how changes affect the existing tool, and remove the need to deploy the changes on some external `gh-pages` site for testing purposes.